### PR TITLE
Calling seq on a non-flat empty rope should return nil.

### DIFF
--- a/src/clj/ropes/core.clj
+++ b/src/clj/ropes/core.clj
@@ -136,7 +136,7 @@
   (seq [this]
     (if (flat? this)
       (seq data)
-      (lazy-cat (seq left) (seq right))))
+      (seq (lazy-cat (seq left) (seq right)))))
 
   Sequential
 


### PR DESCRIPTION
Fix for https://github.com/IGJoshua/ropes/issues/4