### PR TITLE
Fixes

### DIFF
--- a/src/clj/ropes/core.clj
+++ b/src/clj/ropes/core.clj
@@ -102,21 +102,7 @@
       ;; count of the rope is 1, this must be the only leaf node.
       (= 1 cnt) (first data)
       (flat? this) (reduce f data)
-      :else (letfn [(step-reduce
-                      [acc r]
-                      (if (flat? r)
-                        (reduce f acc data)
-                        (-> acc
-                            (step-reduce left)
-                            (step-reduce right))))
-                    (left-reduce
-                      [r]
-                      (if (flat? r)
-                        (reduce f data)
-                        (-> (left-reduce left)
-                            (step-reduce right))))]
-              (-> (left-reduce left)
-                  (step-reduce right)))))
+      :else (reduce f (seq this))))
 
   Indexed
   (nth [_this idx]

--- a/src/clj/ropes/core.clj
+++ b/src/clj/ropes/core.clj
@@ -282,6 +282,9 @@
          ^Rope res
          (or
           (cond
+            (zero? (.-cnt x)) y
+            (zero? (.-cnt y)) x
+
             (and (flat? x)
                  (flat? y))
             (cond

--- a/src/clj/ropes/core.clj
+++ b/src/clj/ropes/core.clj
@@ -44,11 +44,15 @@
                  (< (count data) max-size-for-collapse))
             (Rope. nil nil 0 (inc weight) (inc cnt)
                    (cond
-                     (and (or (nil? data)
-                              (string? data))
-                          (char? s)) (str data s)
+                     (string? data) (if (char? s)
+                                      (str data s)
+                                      ;; convert string data to vector
+                                      (conj (vec data) s))
+
                      (vector? data) (conj data s)
-                     (nil? data) [s]
+                     (nil? data) (if (char? s)
+                                   (str s)
+                                   [s])
                      :else (throw (ex-info "UNREACHABLE: attempted to cons onto a badly-typed rope" {})))
                    meta nil)
 

--- a/src/clj/ropes/core.clj
+++ b/src/clj/ropes/core.clj
@@ -136,7 +136,7 @@
   (seq [this]
     (if (flat? this)
       (seq data)
-      (lazy-cat (seq left) (seq right))))
+      (seq (lazy-cat (seq left) (seq right)))))
 
   Sequential
 

--- a/src/clj/ropes/core.clj
+++ b/src/clj/ropes/core.clj
@@ -335,29 +335,31 @@
   (let [^Rope r (if-not (rope? r) (rope r) r)]
     (when (> idx (.-cnt r))
       (throw (IndexOutOfBoundsException.)))
-    (letfn [(s [^Rope r idx]
-              (if-some [data (.-data r)]
-                (cond
-                  (zero? idx) [(with-meta (rope) (.-meta r)) r]
-                  (= idx (.-cnt r)) [r (with-meta (rope) (.-meta r))]
-                  (string? data) [(rope (subs data 0 idx)) (rope (subs data idx))]
-                  (vector? data) [(rope (subvec data 0 idx)) (rope (subvec data idx))]
-                  :else (throw (ex-info (str "UNREACHABLE: attempted to index an empty or badly-typed rope, but it was not out of bounds") {})))
-                (if (< idx (.-weight r))
-                  (let [[^Rope r1 ^Rope r2] (split (.-left r) idx)]
-                    [r1
-                     (Rope. r2 (.-right r)
-                            (inc (max (.-depth r2)
-                                      (.-depth ^Rope (.-right r))))
-                            (.-cnt r2) (+ (.-cnt r2) (.-cnt ^Rope (.-right r)))
-                            nil (.-meta r) nil)])
-                  (let [[^Rope r1 ^Rope r2] (split (.-right r) (- idx (.-weight r)))]
-                    [(Rope. (.-left r) r1
-                            (inc (max (.-depth ^Rope (.-left r))
-                                      (.-depth r1)))
-                            (.-weight r) (+ (.-weight r) (.-cnt r1)) nil (.-meta r) nil)
-                     r2]))))]
-      (s r idx))))
+    (if (zero? (.-cnt r))
+      [r r]
+      (letfn [(s [^Rope r idx]
+                (if-some [data (.-data r)]
+                  (cond
+                    (zero? idx) [(with-meta (rope) (.-meta r)) r]
+                    (= idx (.-cnt r)) [r (with-meta (rope) (.-meta r))]
+                    (string? data) [(rope (subs data 0 idx)) (rope (subs data idx))]
+                    (vector? data) [(rope (subvec data 0 idx)) (rope (subvec data idx))]
+                    :else (throw (ex-info (str "UNREACHABLE: attempted to index an empty or badly-typed rope, but it was not out of bounds") {})))
+                  (if (< idx (.-weight r))
+                    (let [[^Rope r1 ^Rope r2] (split (.-left r) idx)]
+                      [r1
+                       (Rope. r2 (.-right r)
+                              (inc (max (.-depth r2)
+                                        (.-depth ^Rope (.-right r))))
+                              (.-cnt r2) (+ (.-cnt r2) (.-cnt ^Rope (.-right r)))
+                              nil (.-meta r) nil)])
+                    (let [[^Rope r1 ^Rope r2] (split (.-right r) (- idx (.-weight r)))]
+                      [(Rope. (.-left r) r1
+                              (inc (max (.-depth ^Rope (.-left r))
+                                        (.-depth r1)))
+                              (.-weight r) (+ (.-weight r) (.-cnt r1)) nil (.-meta r) nil)
+                       r2]))))]
+        (s r idx)))))
 
 (defn snip
   "Constructs a new rope without the elements from `start` to `end` in logarithmic

--- a/src/clj/ropes/core.clj
+++ b/src/clj/ropes/core.clj
@@ -120,6 +120,7 @@
         (nth data idx)
         not-found)
       (cond
+        (zero? cnt) not-found
         (< idx weight) (.nth ^Rope left idx not-found)
         (< idx cnt) (.nth ^Rope right (- idx weight) not-found)
         :else not-found)))

--- a/test/ropes/coregen_test.clj
+++ b/test/ropes/coregen_test.clj
@@ -256,18 +256,17 @@
   :ret true?)
 
 
-(defn results->shrunk [fail]
-  (-> fail
+(defn results->shrunk [results]
+  (-> results
       first
       :clojure.spec.test.check/ret
       :shrunk
       :smallest
       first
-      first
-      ))
+      first))
 
-(defn results->fail [fail]
-  (-> (stest/check `compare-ops)
+(defn results->fail [results]
+  (-> results
       first
       :clojure.spec.test.check/ret
       :fail

--- a/test/ropes/coregen_test.clj
+++ b/test/ropes/coregen_test.clj
@@ -60,8 +60,15 @@
                   :replace ::replace-op
                   :split ::split-op))
 
+(s/def ::op-not-new (s/or :view ::view-op
+                          :concat ::concat-op
+                          :insert ::insert-op
+                          :snip ::snip-op
+                          :replace ::replace-op
+                          :split ::split-op))
+
 ;; make sure we start with :new op.
-(s/def ::ops (s/cat :new ::new-rope-op :more (s/* ::op)))
+(s/def ::ops (s/cat :new ::new-rope-op :more (s/* ::op-not-new)))
 
 (comment
   (gen/sample (s/gen ::new-rope-op))

--- a/test/ropes/coregen_test.clj
+++ b/test/ropes/coregen_test.clj
@@ -1,0 +1,229 @@
+(ns ropes.coregen-test
+  (:require
+   [clojure.edn :as edn]
+   [clojure.test :as t]
+   [ropes.core :as sut]
+   [clojure.spec.alpha :as s]
+   [clojure.spec.gen.alpha :as gen]
+   [clojure.spec.test.alpha :as stest]
+   )
+  (:import
+   (java.util ArrayList)))
+
+
+;; instead of generating regular indexes,
+;; generate numbers in the range (0.0 , count)
+;; so that the index can apply to any size eop
+(s/def ::normalized-index (s/double-in :min 0 :max 1))
+(defn ->index
+  "Given a double, in the range [0.0,1.0] return an index [0, (count `coll`)].
+
+  Given two doubles in the range [0.0, 1.0] return a tuple of 2 indices in the range [0, (count `coll`)] 
+  where the 2nd index is guaranteed to be greater than or equal to the first. "
+  ([coll normalized-start normalized-end]
+   (let [cnt (count coll)
+         start (->index coll normalized-start)
+         end (+ start
+                (Math/round (* (- cnt start) normalized-end)))]
+     [start end]))
+  ([coll normalized-index]
+   (Math/round (* (count coll) normalized-index))))
+
+(s/def ::new-rope-content (s/or :nil nil?
+                                :seq seq?
+                                :string string?
+                                :vector (s/coll-of any? :into [])))
+
+(s/def ::new-rope-op (s/spec (s/cat :op #{:new} :s (s/? ::new-rope-content))))
+
+(s/def ::view-op (s/spec (s/cat :op #{:view} :start ::normalized-index :end (s/? ::normalized-index))) )
+
+(s/def ::concat-op (s/spec (s/cat :op #{:concat} :ropes (s/* (s/or :new-rope ::new-rope-op
+                                                                   :last-rope '#{%})) )))
+
+(s/def ::insert-op (s/spec (s/cat :op #{:insert} :idx ::normalized-index :s ::new-rope-content)))
+
+(s/def ::snip-op (s/spec (s/cat :op #{:snip} :start ::normalized-index :end (s/? ::normalized-index))))
+
+(s/def ::replace-op (s/spec (s/cat :op #{:replace} :start ::normalized-index :end ::normalized-index :s ::new-rope-content)))
+
+(s/def ::split-op (s/spec (s/cat :op #{:split} :idx ::normalized-index :left-or-right #{:left :right})))
+
+(s/def ::op (s/or :new ::new-rope-op
+                  :view ::view-op
+                  :concat ::concat-op
+                  :insert ::insert-op
+                  :snip ::snip-op
+                  :replace ::replace-op
+                  :split ::split-op))
+(s/def ::ops (s/cat :new ::new-rope-op :more (s/* ::op)))
+
+(comment
+  (gen/sample (s/gen ::new-rope-op))
+  (gen/sample (s/gen ::normalized-index))
+  (gen/sample (s/gen ::view-op))
+  (gen/sample (s/gen ::concat-op))
+  (gen/sample (s/gen ::insert-op))
+  (gen/sample (s/gen ::snip-op))
+  (gen/sample (s/gen ::split-op))
+  (gen/sample (s/gen ::replace-op))
+  (gen/sample (s/gen ::ops))
+
+  ,)
+
+
+
+(defmulti apply-op (fn [impl-type prev op-type & op-args]
+                     [impl-type op-type]))
+
+
+(defmethod apply-op [:vector :new]
+  ([_ _ _]
+   [])
+  ([_ _ _ s]
+   (into [] s)))
+
+(defmethod apply-op [:vector :view]
+  ([_ prev _ start]
+   (subvec prev
+           (->index prev start)))
+  ([_ prev _ start end]
+   (let [[start end] (->index prev start end)]
+    (subvec prev start end))))
+
+(defmethod apply-op [:vector :concat]
+  ([_ prev _ & args]
+   (into []
+         (comp (map (fn [arg]
+                      (if (= '% arg)
+                        prev
+                        (apply apply-op :vector prev arg))))
+               cat)
+         args)))
+
+(defmethod apply-op [:vector :insert]
+  ([_ prev _ idx s]
+   (let [idx (->index prev idx)]
+     (into []
+           cat
+           [(subvec prev 0 idx)
+            s
+            (subvec prev idx)]))))
+
+(defmethod apply-op [:vector :snip]
+  ([_ prev _ start]
+   (subvec prev (->index prev start)))
+  ([_ prev _ start end]
+   (let [[start end] (->index prev start end)]
+     (into []
+           cat
+           [(subvec prev 0 start)
+            (subvec prev end (count prev))]))))
+
+(defmethod apply-op [:vector :split]
+  ([_ prev _ idx left-or-right]
+   (let [idx (->index prev idx)]
+     (case left-or-right
+       :left (subvec prev 0 idx)
+       :right (subvec prev idx)))))
+
+(defmethod apply-op [:vector :replace]
+  ([_ prev _ start end s]
+   (let [[start end] (->index prev start end)]
+    (into []
+          [(subvec prev 0 start)
+           s
+           (subvec prev end)]))))
+
+
+(defmethod apply-op [:rope :new]
+  ([_ _ _]
+   (sut/rope))
+  ([_ _ _ s]
+   (sut/rope s)))
+
+(defmethod apply-op [:rope :view]
+  ([_ prev _ start]
+   (sut/view prev (->index prev start)))
+  ([_ prev _ start end]
+   (let [[start end] (->index prev start end)]
+     (sut/view prev start end))))
+
+(defmethod apply-op [:rope :concat]
+  ([_ prev _ & args]
+   (apply sut/concat
+          (eduction
+                (map (fn [arg]
+                       (if (= '% arg)
+                         prev
+                         (apply apply-op :rope prev arg))))
+                args))))
+
+(defmethod apply-op [:rope :insert]
+  ([_ prev _ idx s]
+   (sut/insert prev (->index prev idx) s)))
+
+(defmethod apply-op [:rope :snip]
+  ([_ prev _ start]
+   (sut/snip prev (->index prev start)))
+  ([_ prev _ start end]
+   (let [[start end] (->index prev start end)]
+     (sut/snip prev start end))))
+
+(defmethod apply-op [:rope :split]
+  ([_ prev _ idx left-or-right]
+   (let [idx (->index prev idx)]
+     (case left-or-right
+       :left (-> (sut/split prev idx) first)
+       :right (-> (sut/split prev idx) second)))))
+
+(defmethod apply-op [:rope :replace]
+  ([_ prev _ start end s]
+   (let [[start end] (->index prev start end)]
+     (sut/replace prev start end s))))
+
+
+(defn apply-ops [impl-type ops]
+  (reduce
+   (fn [prev op]
+     (apply apply-op impl-type prev op))
+   nil
+   ops))
+
+(comment
+  (apply-ops :rope (gen/generate (s/gen ::ops)))
+
+  (def my-ops (gen/sample (s/gen ::ops) 1000))
+  (def matches (atom []))
+  (def running? (atom true))
+  (defn stop []
+    (reset! running? false))
+  (future
+    (reset! running? true)
+    (doseq [ops my-ops
+            :when @running? ]
+      (let [success? (try
+                       (= (apply-ops :vector ops)
+                          (apply-ops :rope ops))
+                       (catch Throwable t
+                         nil))]
+        (when success?
+          (let [new-matches (swap! matches conj ops)]
+            (println "found match!" (count new-matches)))))))
+
+  ,)
+
+
+(defn compare-ops [ops]
+  (= (apply-ops :vector ops)
+     (apply-ops :rope ops)))
+(s/fdef compare-ops
+  :args (s/cat :ops (s/spec ::ops))
+  :ret true?)
+
+
+
+(comment
+  (stest/check `compare-ops)
+
+  ,)

--- a/test/ropes/coregen_test.clj
+++ b/test/ropes/coregen_test.clj
@@ -112,7 +112,7 @@
 
 (defmethod apply-op [:vector :snip]
   ([_ prev _ start]
-   (subvec prev (->index prev start)))
+   (subvec prev 0 (->index prev start)))
   ([_ prev _ start end]
    (let [[start end] (->index prev start end)]
      (into []

--- a/test/ropes/coregen_test.clj
+++ b/test/ropes/coregen_test.clj
@@ -131,6 +131,7 @@
   ([_ prev _ start end s]
    (let [[start end] (->index prev start end)]
     (into []
+          cat
           [(subvec prev 0 start)
            s
            (subvec prev end)]))))


### PR DESCRIPTION
This pull requests improves the coverage of the generative tests. It also includes individual deftests for individual issues that were found.

All of the issues found have been fixed.

For review, I think the most controversial changes are:

- support for caching hasheq hash values (requires adding a new field to the Rope class)
- removing the fast path for `(reduce f rope)`. This function was the cause of several subtle bugs. The problem is that for `(reduce f rope)` without an init value, you need to find the first and second items in the collection to seed the reduce. That's pretty easy if the first and second value are in the data of a single node, but the first value could be buried somewhere arbitrarily deep and the second value could be buried in another node that's arbitrarily deep. I also don't feel too bad because I'm not sure why anyone would want to omit the init value anyway.

I may have gotten a bit carried away. I'd be happy to do any rebasing or reformatting you prefer. I put the commits that improve the tests before the commits that implement the fixes so that you can revert back to before the fixes were implemented and just make fixes based off the tests.